### PR TITLE
[IMP][CL] El módulo report_xlsx se vuelve auto instalable

### DIFF
--- a/report_xlsx/__manifest__.py
+++ b/report_xlsx/__manifest__.py
@@ -13,6 +13,7 @@
     "depends": ["base", "web"],
     "demo": ["demo/report.xml"],
     "installable": True,
+    'auto_install': True, # Modificación de Trescloud para que se instale automáticamente
     "assets": {
         "web.assets_backend": [
             "report_xlsx/static/src/js/report/action_manager_report.esm.js",


### PR DESCRIPTION
Se hace autoinstalable para que módulos como [partner_statement (Odoo-apps)](https://github.com/TRESCLOUD/odoo-apps/tree/18.0/partner_statement) y https://github.com/TRESCLOUD/purchase-and-imports/tree/18.0/l10n_ec_landed_cost_report se instalen automáticamente